### PR TITLE
Add TroveQL Get Method Tests

### DIFF
--- a/TroveMetrics/package.json
+++ b/TroveMetrics/package.json
@@ -37,6 +37,7 @@
     "electron": "23.1.4",
     "express": "^4.18.2",
     "fs": "^0.0.1-security",
+    "jest": "^29.5.0",
     "node-loader": "^2.0.0",
     "react-chartjs-2": "^5.2.0",
     "sass": "^1.60.0",

--- a/TroveQL/__tests__/troveql-cache.test.js
+++ b/TroveQL/__tests__/troveql-cache.test.js
@@ -1,0 +1,63 @@
+//TESTS FOR CACHE
+const { afterEach } = require('node:test');
+const { TroveCache } = require('../dist/arc/arc.js');
+const { CacheItem } = require('../dist/arc/cacheItem');
+
+describe('TroveCache', () => {
+  let troveCache;
+
+  beforeEach(() => {
+    troveCache = new TroveCache(4);
+  });
+
+  afterEach(() => {
+    troveCache.removeAll();
+  });
+
+  describe('get method tests', () => {
+    it("returns { result: '', miss: 'miss' } when the cache is empty", () => {
+      expect(troveCache.get('Query1')).toEqual({ result: '', miss: 'miss' });
+    });
+
+    it('returns the cached item value and sets it to the t1 cache partition when the query is found in t1', () => {
+      const result1 = new CacheItem('Result1');
+      troveCache.t1.set('Query1', result1);
+
+      expect(troveCache.get('Query1')).toEqual({
+        result: 'Result1',
+        miss: false,
+      });
+
+      expect(troveCache.t2.get('Query1')).toEqual({
+        hits: 0,
+        value: 'Result1',
+      });
+    });
+  });
+
+  it('returns the cached item value and sets it to the t2 cache partition when the query is found in t1', () => {
+    const result2 = new CacheItem('Result2');
+    troveCache.t2.set('Query2', result2);
+    expect(troveCache.get('Query2')).toEqual({
+      result: 'Result2',
+      miss: false,
+    });
+
+    expect(troveCache.t2.get('Query2')).toEqual({
+      hits: 0,
+      value: 'Result2',
+    });
+  });
+
+  it("returns { result: '', miss: 'b1' } when the query is found in b1 but not in t1 ,t2 and b2", () => {
+    troveCache.b1.set('Query3', 'false');
+    expect(troveCache.get('Query3')).toEqual({ result: '', miss: 'b1' });
+  });
+
+  it("returns { result: '', miss: 'b2' } when the query is found in b2 but not in t1, t2, and b1", () => {
+    troveCache.b2.set('Query4', 'false');
+    expect(troveCache.get('Query4')).toEqual({ result: '', miss: 'b2' });
+  });
+});
+
+describe('set method tests', () => {});

--- a/TroveQL/package.json
+++ b/TroveQL/package.json
@@ -9,7 +9,8 @@
     "caching"
   ],
   "scripts": {
-    "build": "tsc --watch"
+    "build": "tsc --watch",
+    "test": "jest"
   },
   "repository": "https://github.com/oslabs-beta/troveql",
   "author": "Erika Jung, Sam Henderson, Tricia Yeh, & Alex Klein",

--- a/TroveQL/src/arc/arc.ts
+++ b/TroveQL/src/arc/arc.ts
@@ -1,11 +1,6 @@
 import { CacheItem } from './cacheItem';
 
-import {
-  ItemType,
-  CacheType,
-  ResponseType,
-  CacheSizeType,
-} from './arcTypes';
+import { ItemType, CacheType, ResponseType, CacheSizeType } from './arcTypes';
 
 export class TroveCache {
   capacity: number;
@@ -25,7 +20,6 @@ export class TroveCache {
   }
 
   public get = (query: string): ResponseType => {
-    console.log('---arc get method query input: ', query);
     switch (true) {
       case this.t1.has(query) || this.t2.has(query):
         console.log('In Get Case I');
@@ -122,7 +116,7 @@ export class TroveCache {
   private evictLRU(cache: CacheType) {
     const firstKey = cache.keys().next().value;
     // will the following line pass by ref? Do we need to make a shallow copy?
-    const evicted = [firstKey, cache.get(firstKey)];
+    const evicted = firstKey;
     cache.delete(firstKey);
     return evicted;
   }
@@ -132,11 +126,11 @@ export class TroveCache {
       this.t1.size > 0 &&
       (this.t1.size > this.p || (foundInB2 && this.t1.size === this.p))
     ) {
-      let [key, cacheItem] = this.evictLRU(this.t1);
-      this.b1.set(key, cacheItem);
+      let key = this.evictLRU(this.t1);
+      this.b1.set(key, true);
     } else {
-      let [key, cacheItem] = this.evictLRU(this.t2);
-      this.b2.set(key, cacheItem);
+      let key = this.evictLRU(this.t2);
+      this.b2.set(key, true);
     }
   }
 


### PR DESCRIPTION
- Add Jest test framework to TroveQL
- Add tests for TroveCache 'get' method
- Fix bug with TroveCache where ghost items were not being property evicted 